### PR TITLE
Adopt a consistent rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 80
+use_small_heuristics = "Max"
+newline_style = "Unix"


### PR DESCRIPTION
Adopt a more "standard" rustfmt.toml and format.
This change is purely mechanical.