### PR TITLE
Refactoring amd-flash.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 name = "amd-flash"
 version = "0.2.1"
 authors = ["dannym"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+static_assertions = "1.1"
 thiserror = { version = "1.0.38", optional = true }
 
 [features]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-12-29"
+channel = "nightly-2023-10-09"
 components = [ "rustfmt", "rust-src" ]

--- a/src/allocators.rs
+++ b/src/allocators.rs
@@ -1,66 +1,60 @@
-use crate::{ErasableRange, Location};
+use crate::block;
 use crate::{Error, Result};
+use crate::{Location, Range};
 
-pub trait FlashAllocate {
-    fn take_at_least(&mut self, size: usize) -> Option<ErasableRange>;
-    fn max_contiguous_capacity(&self) -> usize;
+pub struct ArenaAllocator<const BSIZE: block::Size> {
+    _efh_range: Range<BSIZE>,
+    arenas: [Range<BSIZE>; 2],
 }
 
-pub struct ArenaFlashAllocator {
-    _efh_range: ErasableRange,
-    free_ranges: [ErasableRange; 2],
-}
-
-impl ArenaFlashAllocator {
+impl<const BSIZE: block::Size> ArenaAllocator<BSIZE> {
     /// Creates a new allocator that will use parts of the given ARENA.
     /// Depending on processor generation, a part of it will be cut out
     /// and not given to the user (since it needs to be at a fixed
     /// spot and also is used by us).
-    pub fn new(
-        efh_beginning: Location,
+    pub fn try_new(
+        efh_start: Location<BSIZE>,
         efh_size: usize,
-        arena: ErasableRange,
+        mut arena: Range<BSIZE>,
     ) -> Result<Self> {
-        let mut arena = arena;
-        assert!(Location::from(arena.beginning) == 0);
+        assert!(<Location<BSIZE> as Into<usize>>::into(arena.start) == 0_usize);
         // Avoid EFH_BEGINNING..(EFH_BEGINNING + EFH_SIZE)
-        let a_size = efh_beginning as usize;
-        let a = arena.take_at_least(a_size).ok_or(Error::Size)?;
-        assert!(Location::from(a.end) as usize == a_size);
-        let _efh_range = arena.take_at_least(efh_size).ok_or(Error::Size)?;
-        Ok(Self { _efh_range, free_ranges: [a, arena] })
+        let a_size = efh_start.into();
+        let a = arena.split_round_up(a_size).ok_or(Error::Size)?;
+        assert!(a.end == efh_start);
+        let _efh_range = arena.split_round_up(efh_size).ok_or(Error::Size)?;
+        Ok(Self { _efh_range, arenas: [a, arena] })
     }
 }
-impl FlashAllocate for ArenaFlashAllocator {
+impl<const BSIZE: block::Size> crate::Allocator<BSIZE>
+    for ArenaAllocator<BSIZE>
+{
     /// From the free ranges, take a range of at least SIZE Bytes,
     /// if possible. Otherwise return None.
-    fn take_at_least(&mut self, size: usize) -> Option<ErasableRange> {
-        self.free_ranges[0]
-            .take_at_least(size)
-            .or_else(|| self.free_ranges[1].take_at_least(size))
+    fn alloc_round_up(&mut self, size: usize) -> Option<Range<BSIZE>> {
+        self.arenas[0]
+            .split_round_up(size)
+            .or_else(|| self.arenas[1].split_round_up(size))
     }
+
     fn max_contiguous_capacity(&self) -> usize {
-        let mut max_capacity = 0usize;
-        for range in &self.free_ranges {
-            let capacity = range.capacity();
-            if capacity > max_capacity {
-                max_capacity = capacity
-            }
-        }
-        max_capacity
+        self.arenas.iter().max_by_key(|&r| r.size()).unwrap().size()
     }
 }
 
 #[cfg(test)]
 mod allocator_tests {
-    use super::super::{FlashAlign, Location};
     use super::*;
+    use crate::Allocator;
+
+    const BSIZE: block::Size = block::Size::B4K;
+
     fn intersect(
-        a: &ErasableRange,
-        b: &ErasableRange,
-    ) -> Option<(Location, Location)> {
+        a: &Range<BSIZE>,
+        b: &Range<BSIZE>,
+    ) -> Option<(Location<BSIZE>, Location<BSIZE>)> {
         let new_beginning =
-            Location::from(a.beginning).max(Location::from(b.beginning));
+            Location::from(a.start).max(Location::from(b.start));
         let new_end = Location::from(a.end).min(Location::from(b.end));
         if new_beginning < new_end {
             Some((new_beginning, new_end))
@@ -68,70 +62,58 @@ mod allocator_tests {
             None
         }
     }
-    struct Buffer {}
-    impl FlashAlign for Buffer {
-        fn erasable_block_size(&self) -> usize {
-            4
-        }
+
+    fn allocator() -> ArenaAllocator<BSIZE> {
+        let start = Location::try_new(0).unwrap();
+        let end = start.add_round_up(0x4_0000).unwrap();
+        ArenaAllocator::try_new(
+            Location::try_new(0x2_0000).unwrap(),
+            0x200,
+            Range::new(start, end),
+        )
+        .unwrap()
     }
-    impl Buffer {
-        fn allocator(&self) -> ArenaFlashAllocator {
-            let beginning = self.erasable_location(0).unwrap();
-            let end = beginning.advance_at_least(0x4_0000).unwrap();
-            ArenaFlashAllocator::new(
-                0x2_0000,
-                0x200,
-                ErasableRange::new(beginning, end),
-            )
-            .unwrap()
-        }
-        fn efh_range(&self) -> ErasableRange {
-            ErasableRange::new(
-                self.erasable_location(0x2_0000).unwrap(),
-                self.erasable_location(0x2_0000)
-                    .unwrap()
-                    .advance_at_least(0x200)
-                    .unwrap(),
-            )
-        }
+    fn efh_range() -> Range<BSIZE> {
+        Range::new(
+            Location::try_new(0x2_0000).unwrap(),
+            Location::try_new(0x2_0000).unwrap().add_round_up(0x200).unwrap(),
+        )
     }
+
     #[test]
     fn test_allocator_1() {
-        let buf = Buffer {};
-        let mut allocator = buf.allocator();
-        let efh_range = buf.efh_range();
-        let a = allocator.take_at_least(42).unwrap();
-        let b = allocator.take_at_least(100).unwrap();
+        let mut alloc = allocator();
+        let efh_range = efh_range();
+        let a = alloc.alloc_round_up(42).unwrap();
+        let b = alloc.alloc_round_up(100).unwrap();
         assert!(intersect(&a, &b).is_none());
         assert!(intersect(&a, &efh_range).is_none());
         assert!(intersect(&b, &efh_range).is_none());
-        assert!(Location::from(b.end) < 0x2_0000);
+        assert!(<Location<BSIZE> as Into<usize>>::into(b.end) < 0x2_0000);
     }
 
     #[test]
     fn test_allocator_2() {
-        let buf = Buffer {};
-        let mut allocator = buf.allocator();
-        let efh_range = buf.efh_range();
-        let a = allocator.take_at_least(0x2_0000).unwrap();
-        let b = allocator.take_at_least(100).unwrap();
+        let mut alloc = allocator();
+        let efh_range = efh_range();
+        let a = alloc.alloc_round_up(0x2_0000).unwrap();
+        let b = alloc.alloc_round_up(100).unwrap();
         assert!(intersect(&a, &b).is_none());
         assert!(intersect(&a, &efh_range).is_none());
         assert!(intersect(&b, &efh_range).is_none());
-        assert!(Location::from(b.end) < 0x4_0000);
+        assert!(<Location<BSIZE> as Into<usize>>::into(b.end) < 0x4_0000);
     }
 
     #[test]
     fn test_allocator_3() {
-        let buf = Buffer {};
-        let mut allocator = buf.allocator();
-        let efh_range = buf.efh_range();
-        let a = allocator.take_at_least(0x1_fff8).unwrap();
-        let b = allocator.take_at_least(100).unwrap();
+        let mut alloc = allocator();
+        let efh_range = efh_range();
+        let a = alloc.alloc_round_up(0x1_fff8).unwrap();
+        let b = alloc.alloc_round_up(100).unwrap();
         assert!(intersect(&a, &b).is_none());
         assert!(intersect(&a, &efh_range).is_none());
         assert!(intersect(&b, &efh_range).is_none());
-        assert!(Location::from(b.end) < 0x4_0000);
-        assert!(Location::from(b.beginning) > 0x2_0000);
+        assert!(<Location<BSIZE> as Into<usize>>::into(b.end) < 0x4_0000);
+        assert!(<Location<BSIZE> as Into<usize>>::into(b.start) > 0x2_0000);
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,110 @@
+use core::marker::ConstParamTy;
+
+const KIB: usize = 1024;
+
+#[derive(Clone, ConstParamTy, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum Size {
+    B4K = 4 * KIB,
+    B8K = 8 * KIB,
+    B12K = 12 * KIB,
+    B16K = 16 * KIB,
+    B20K = 20 * KIB,
+    B24K = 24 * KIB,
+    B28K = 28 * KIB,
+    B32K = 32 * KIB,
+    B36K = 36 * KIB,
+    B40K = 40 * KIB,
+    B44K = 44 * KIB,
+    B48K = 48 * KIB,
+    B52K = 52 * KIB,
+    B56K = 56 * KIB,
+    B60K = 60 * KIB,
+    B64K = 64 * KIB,
+}
+
+impl Size {
+    /// Returns true if the given integer is a multiple of self.
+    pub const fn is_aligned(self, n: usize) -> bool {
+        matches!(self.align_up(n), Some(nn) if nn == n)
+    }
+
+    /// Returns Some(n rounded to the next multiple) of self,
+    /// or None on overflow.
+    pub const fn align_up(self, n: usize) -> Option<usize> {
+        n.checked_next_multiple_of(self as usize)
+    }
+
+    /// Tries to convert a number representing the block size
+    /// into a Size variant.
+    pub const fn try_from_block_size(block_size: u32) -> Option<Size> {
+        match block_size {
+            0 => Some(Size::B64K),
+            1 => Some(Size::B4K),
+            2 => Some(Size::B8K),
+            3 => Some(Size::B12K),
+            4 => Some(Size::B16K),
+            5 => Some(Size::B20K),
+            6 => Some(Size::B24K),
+            7 => Some(Size::B28K),
+            8 => Some(Size::B32K),
+            9 => Some(Size::B36K),
+            10 => Some(Size::B40K),
+            11 => Some(Size::B44K),
+            12 => Some(Size::B48K),
+            13 => Some(Size::B52K),
+            14 => Some(Size::B56K),
+            15 => Some(Size::B60K),
+            _ => None,
+        }
+    }
+}
+
+impl From<Size> for usize {
+    /// Conversions from Size to usize are infallible.
+    fn from(s: Size) -> usize {
+        s as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_aligned() {
+        assert!(Size::B4K.is_aligned(0));
+        assert!(Size::B4K.is_aligned(4096));
+        assert!(Size::B4K.is_aligned(8192));
+        assert!(!Size::B4K.is_aligned(1));
+    }
+
+    #[test]
+    fn align_up() {
+        assert_eq!(Size::B4K.align_up(0), Some(0));
+        assert_eq!(Size::B4K.align_up(1), Some(4096));
+        assert_eq!(Size::B4K.align_up(4096), Some(4096));
+    }
+
+    #[test]
+    fn from_impl() {
+        assert_eq!(4096_usize, Size::B4K.into());
+        assert_eq!(8192_usize, Size::B8K.into());
+        assert_eq!(12 * KIB, Size::B12K.into());
+        assert_eq!(16 * KIB, Size::B16K.into());
+        assert_eq!(32 * KIB, Size::B32K.into());
+        assert_eq!(64 * KIB, Size::B64K.into());
+    }
+
+    #[test]
+    fn try_from_block_size() {
+        assert_eq!(Size::try_from_block_size(0), Some(Size::B64K));
+        for k in 1..16 {
+            let size = Size::try_from_block_size(k);
+            assert!(size.is_some());
+            let n = usize::from(size.unwrap());
+            assert_eq!(k as usize * 4 * KIB, n);
+        }
+        assert!(Size::try_from_block_size(16).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,188 +3,151 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(incomplete_features)]
+#![feature(adt_const_params)]
 
 use core::convert::TryInto;
-pub mod allocators;
 
-#[derive(Debug)]
+pub mod allocators;
+pub mod block;
+
+#[derive(Clone, Debug, Copy)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
     #[cfg_attr(feature = "std", error("io"))]
     Io,
-    #[cfg_attr(
-        feature = "std",
-        error("alignment is not good enough for erasability of block")
-    )]
+    #[cfg_attr(feature = "std", error("block not aligned for erase"))]
     Alignment,
     #[cfg_attr(feature = "std", error("programmer violated an invariant"))]
     Programmer,
-    #[cfg_attr(
-        feature = "std",
-        error("no area of requested size is available")
-    )]
+    #[cfg_attr(feature = "std", error("requested size is unavailable"))]
     Size,
+    #[cfg_attr(feature = "std", error("overflow"))]
+    Overflow,
 }
 
-pub type Result<Q> = core::result::Result<Q, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
-/// This is any Location on the Flash chip
-pub type Location = u32;
+/// A flash location that is aligned on a block boundary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Location<const BSIZE: block::Size>(u32);
 
-/// This is a Location which definitely is aligned on an erase block boundary
-#[derive(Clone, Copy, Debug)]
-pub struct ErasableLocation {
-    location: Location,
-    erasable_block_size: usize,
-}
-
-impl ErasableLocation {
-    pub fn erasable_block_size(&self) -> usize {
-        self.erasable_block_size
-    }
-    pub fn erasable_block_mask(&self) -> u32 {
-        (self.erasable_block_size as u32) - 1
-    }
-    /// Note: Assumed beginning <= self, otherwise result will be 0.
-    pub fn extent(beginning: Self, end: Self) -> u32 {
-        let beginning = beginning.location;
-        let end = end.location;
-        end.saturating_sub(beginning)
-    }
-    pub fn advance(&self, amount: usize) -> Result<Self> {
-        if amount & (self.erasable_block_mask() as usize) != 0 {
+impl<const BSIZE: block::Size> Location<BSIZE> {
+    pub fn try_new(loc: u32) -> Result<Location<BSIZE>> {
+        if !BSIZE.is_aligned(loc.try_into().unwrap()) {
             return Err(Error::Alignment);
         }
-        let pos = (self.location as usize)
-            .checked_add(amount)
-            .ok_or(Error::Alignment)?;
-        Ok(Self {
-            location: pos.try_into().map_err(|_| Error::Alignment)?,
-            erasable_block_size: self.erasable_block_size,
-        })
+        Ok(Location(loc))
     }
-    pub fn advance_at_least(&self, amount: usize) -> Result<Self> {
-        // Round up to a multiple of erasable_block_size()
-        let diff =
-            0usize.wrapping_sub(amount) & (self.erasable_block_mask() as usize);
-        let amount = amount.checked_add(diff).ok_or(Error::Alignment)?;
-        self.advance(amount)
+
+    pub fn add(&self, amount: usize) -> Result<Self> {
+        if !BSIZE.is_aligned(amount) {
+            return Err(Error::Alignment);
+        }
+        let amount: u32 = amount.try_into().map_err(|_| Error::Overflow)?;
+        let location: u32 = self.0;
+        let pos = location.checked_add(amount).ok_or(Error::Overflow)?;
+        Location::try_new(pos)
+    }
+
+    /// Round up to a multiple of block size.
+    pub fn add_round_up(&self, amount: usize) -> Result<Self> {
+        let amount = BSIZE.align_up(amount).ok_or(Error::Alignment)?;
+        self.add(amount)
+    }
+
+    /// Note: Assumed start <= end, otherwise result will be 0.
+    pub fn diff(start: Self, end: Self) -> u32 {
+        end.0.saturating_sub(start.0)
     }
 }
 
-impl From<ErasableLocation> for Location {
-    fn from(source: ErasableLocation) -> Self {
-        source.location
+impl<const BSIZE: block::Size> From<Location<BSIZE>> for u32 {
+    fn from(val: Location<BSIZE>) -> Self {
+        val.0
+    }
+}
+
+impl<const BSIZE: block::Size> From<Location<BSIZE>> for usize {
+    fn from(val: Location<BSIZE>) -> Self {
+        val.0.try_into().unwrap()
+    }
+}
+
+pub trait Allocator<const BSIZE: block::Size> {
+    fn alloc_round_up(&mut self, size: usize) -> Option<Range<BSIZE>>;
+    fn max_contiguous_capacity(&self) -> usize;
+}
+
+/// A marker trait that signifies that a type is aligned on some boundary.
+pub trait Aligned<const BSIZE: block::Size> {}
+
+pub trait Read<const BSIZE: block::Size> {
+    /// Read exactly the right amount from the location to fill the
+    /// entire BUFFER that was passed.
+    fn read_exact(&self, loc: Location<BSIZE>, buf: &mut [u8]) -> Result<()>;
+
+    /// Reads a block of data.
+    fn read_block(&self, loc: Location<BSIZE>, buf: &mut [u8]) -> Result<()> {
+        if buf.len() != usize::from(BSIZE) {
+            return Err(Error::Programmer);
+        }
+        self.read_exact(loc, buf)
+    }
+}
+
+pub trait Write<const BSIZE: block::Size>: Read<BSIZE> {
+    /// Erase a block at the given location.
+    fn erase(&self, loc: Location<BSIZE>) -> Result<()>;
+
+    /// Writes a block, erasing the remainder if the given data
+    /// are shorter than a block.
+    fn write_block(&self, location: Location<BSIZE>, buf: &[u8]) -> Result<()>;
+
+    /// Writes data into contiguous blocks starting at the given
+    /// location.
+    fn write(&self, mut location: Location<BSIZE>, buf: &[u8]) -> Result<()> {
+        let bsize = usize::from(BSIZE);
+        for chunk in buf.chunks(bsize) {
+            self.write_block(location, chunk)?;
+            if chunk.len() != bsize {
+                // TODO: Only allow on last chunk
+                break;
+            }
+            location = location.add(bsize)?;
+        }
+        Ok(())
     }
 }
 
 #[derive(Debug)]
-pub struct ErasableRange {
-    pub beginning: ErasableLocation, // note: same erasable_block_size assumed
-    pub end: ErasableLocation,       // note: same erasable_block_size assumed
+pub struct Range<const B: block::Size> {
+    pub start: Location<B>,
+    pub end: Location<B>,
 }
-impl ErasableRange {
-    pub fn new(beginning: ErasableLocation, end: ErasableLocation) -> Self {
-        assert!(Location::from(beginning) <= Location::from(end)); // TODO nicer
-        Self { beginning, end }
+
+impl<const B: block::Size> Range<B> {
+    /// Creates a new range of flash locations covering between [start, end).
+    pub fn new(start: Location<B>, end: Location<B>) -> Self {
+        assert!(start <= end);
+        Self { start, end }
     }
+
     /// Splits the Range after at least SIZE Byte, if possible.
     /// Return the first part. Retain the second part.
-    pub fn take_at_least(&mut self, size: usize) -> Option<Self> {
-        let x_beginning = self.beginning;
-        let x_end = self.beginning.advance_at_least(size).ok()?;
-        if Location::from(x_end) <= Location::from(self.end) {
-            *self = Self::new(x_end, self.end);
-            Some(Self::new(x_beginning, x_end))
-        } else {
-            None
+    pub fn split_round_up(&mut self, size: usize) -> Option<Self> {
+        let start = self.start;
+        let end = self.start.add_round_up(size).ok()?;
+        if end > self.end {
+            return None;
         }
+        *self = Self::new(end, self.end);
+        Some(Self::new(start, end))
     }
-    /// in Byte
-    pub fn capacity(&self) -> usize {
-        ErasableLocation::extent(self.beginning, self.end) as usize
-    }
-}
 
-pub trait FlashRead {
-    /// Read exactly the right amount from the location BEGINNING to fill the
-    /// entire BUFFER that was passed.
-    fn read_exact(&self, beginning: Location, buffer: &mut [u8]) -> Result<()>;
-}
-
-pub trait FlashAlign {
-    /// Note: Assumed constant for lifetime of instance.
-    /// Note: Assumed to be a power of two.
-    fn erasable_block_size(&self) -> usize;
-    fn erasable_block_mask(&self) -> u32 {
-        (self.erasable_block_size() as u32) - 1
-    }
-    fn is_aligned(&self, location: Location) -> bool {
-        (location & self.erasable_block_mask()) == 0
-    }
-    /// Determine an erasable location, given a location, if possible.
-    /// If not possible, return None.
-    fn erasable_location(
-        &self,
-        location: Location,
-    ) -> Option<ErasableLocation> {
-        let erasable_block_size = self.erasable_block_size();
-        self.is_aligned(location)
-            .then_some(ErasableLocation { location, erasable_block_size })
-    }
-    /// Given an erasable location, returns the corresponding location
-    /// IF the erasable location is compatible with our instance.
-    fn location(
-        &self,
-        erasable_location: ErasableLocation,
-    ) -> Result<Location> {
-        if erasable_location.erasable_block_size == self.erasable_block_size() {
-            Ok(erasable_location.location)
-        } else {
-            Err(Error::Alignment)
-        }
-    }
-}
-
-pub trait FlashWrite: FlashRead + FlashAlign {
-    /// Note: BUFFER.len() == erasable_block_size()
-    fn read_erasable_block(
-        &self,
-        location: ErasableLocation,
-        buffer: &mut [u8],
-    ) -> Result<()> {
-        if buffer.len() != self.erasable_block_size() {
-            return Err(Error::Programmer);
-        }
-        self.read_exact(self.location(location)?, buffer)?;
-        Ok(())
-    }
-    fn erase_block(&self, location: ErasableLocation) -> Result<()>;
-    /// Note: If BUFFER.len() < erasable_block_size(), it has to erase the
-    /// remainder anyway.
-    fn erase_and_write_block(
-        &self,
-        location: ErasableLocation,
-        buffer: &[u8],
-    ) -> Result<()>;
-
-    // FIXME: sanity check callers
-    fn erase_and_write_blocks(
-        &self,
-        location: ErasableLocation,
-        buf: &[u8],
-    ) -> Result<()> {
-        let mut location = location;
-        let erasable_block_size = self.erasable_block_size();
-        for chunk in buf.chunks(erasable_block_size) {
-            self.erase_and_write_block(location, chunk)?;
-            if chunk.len() != erasable_block_size {
-                // TODO: Only allow on last chunk
-                break;
-            }
-            location = location.advance(erasable_block_size)?;
-        }
-        Ok(())
+    /// Returns the size of the range in bytes.
+    pub fn size(&self) -> usize {
+        Location::diff(self.start, self.end) as usize
     }
 }
 
@@ -192,102 +155,68 @@ pub trait FlashWrite: FlashRead + FlashAlign {
 mod tests {
     use super::*;
     use core::cell::RefCell;
-    const KIB: usize = 1024; // B
-    const ERASABLE_BLOCK_SIZE: usize = 128 * KIB;
+
+    const BSIZE: block::Size = block::Size::B64K;
+    const BLOCK_SIZE: usize = BSIZE as usize;
 
     struct FlashImage<'a> {
         buf: RefCell<&'a mut [u8]>,
-        erasable_block_size: usize,
     }
 
     impl<'a> FlashImage<'a> {
         pub fn new(buf: &'a mut [u8]) -> Self {
-            Self {
-                buf: RefCell::new(buf),
-                erasable_block_size: ERASABLE_BLOCK_SIZE,
-            }
+            Self { buf: RefCell::new(buf) }
         }
     }
 
-    impl FlashRead for FlashImage<'_> {
+    impl Read<BSIZE> for FlashImage<'_> {
         fn read_exact(
             &self,
-            location: Location,
-            buffer: &mut [u8],
+            loc: Location<BSIZE>,
+            dst: &mut [u8],
         ) -> Result<()> {
-            let len = buffer.len();
-            let buf = self.buf.borrow();
-            let block = &buf[location as usize..];
-            let block = &block[0..len];
-            buffer[..].copy_from_slice(block);
+            let src = self.buf.borrow();
+            let loc = usize::from(loc);
+            let block = &src[loc..loc + dst.len()];
+            dst.copy_from_slice(block);
             Ok(())
         }
     }
 
-    impl FlashAlign for FlashImage<'_> {
-        fn erasable_block_size(&self) -> usize {
-            self.erasable_block_size
-        }
-    }
-    impl FlashWrite for FlashImage<'_> {
-        fn read_erasable_block(
-            &self,
-            location: ErasableLocation,
-            buffer: &mut [u8],
-        ) -> Result<()> {
-            let erasable_block_size = self.erasable_block_size();
-            let location: Location = location.into();
-            let buf = self.buf.borrow();
-            let block = &buf
-                [location as usize..(location as usize + erasable_block_size)];
-            if buffer.len() != erasable_block_size {
-                return Err(Error::Programmer);
-            }
-            buffer[..].copy_from_slice(block);
-            Ok(())
-        }
-        fn erase_block(&self, location: ErasableLocation) -> Result<()> {
-            let location: Location = location.into();
+    impl Write<BSIZE> for FlashImage<'_> {
+        fn erase(&self, loc: Location<BSIZE>) -> Result<()> {
             let mut buf = self.buf.borrow_mut();
-            let block = &mut buf[location as usize
-                ..(location as usize + self.erasable_block_size())];
+            let loc = usize::from(loc);
+            let block = &mut buf[loc..loc + usize::from(BSIZE)];
             block.fill(0xff);
             Ok(())
         }
-        fn erase_and_write_block(
-            &self,
-            location: ErasableLocation,
-            buffer: &[u8],
-        ) -> Result<()> {
-            let location: Location = location.into();
-            let mut buf = self.buf.borrow_mut();
-            let block = &mut buf[location as usize
-                ..(location as usize + self.erasable_block_size())];
-            block.copy_from_slice(&buffer[..]);
+
+        fn write_block(&self, loc: Location<BSIZE>, src: &[u8]) -> Result<()> {
+            let mut dst = self.buf.borrow_mut();
+            let loc = usize::from(loc);
+            let block = &mut dst[loc..loc + usize::from(BSIZE)];
+            block.copy_from_slice(src);
             Ok(())
         }
     }
 
     #[test]
     fn flash_image_usage() -> Result<()> {
-        let mut storage = [0xFFu8; 256 * KIB];
-        let flash_image = FlashImage::new(&mut storage[..]);
-        let beginning_1 =
-            flash_image.erasable_location(Location::from(0u32)).unwrap();
-        let erasable_block_size = ERASABLE_BLOCK_SIZE;
-        flash_image
-            .erase_and_write_block(beginning_1, &[1u8; ERASABLE_BLOCK_SIZE])?;
-        let beginning_2 = flash_image
-            .erasable_location(Location::from(erasable_block_size as u32))
-            .unwrap();
-        flash_image
-            .erase_and_write_block(beginning_2, &[2u8; ERASABLE_BLOCK_SIZE])?;
-        let mut buf: [u8; ERASABLE_BLOCK_SIZE] = [0u8; ERASABLE_BLOCK_SIZE];
-        flash_image.read_exact(0, &mut buf)?;
-        assert_eq!(buf, [1u8; ERASABLE_BLOCK_SIZE]);
-        flash_image
-            .read_exact(Location::from(erasable_block_size as u32), &mut buf)?;
-        assert_eq!(buf, [2u8; ERASABLE_BLOCK_SIZE]);
+        let mut storage = [0xFFu8; BLOCK_SIZE * 2];
+        let image = FlashImage::new(&mut storage[..]);
+        let beginning_1 = Location::try_new(0).unwrap();
+        image.write_block(beginning_1, &[1u8; BLOCK_SIZE])?;
+        let beginning_2 = Location::try_new(BLOCK_SIZE as u32).unwrap();
+        image.write_block(beginning_2, &[2u8; BLOCK_SIZE])?;
+        let mut buf: [u8; BLOCK_SIZE] = [0u8; BLOCK_SIZE];
+        image.read_exact(Location::try_new(0).unwrap(), &mut buf)?;
+        assert_eq!(buf, [1u8; BLOCK_SIZE]);
+        image.read_exact(
+            Location::try_new(BLOCK_SIZE as u32).unwrap(),
+            &mut buf,
+        )?;
+        assert_eq!(buf, [2u8; BLOCK_SIZE]);
         Ok(())
     }
 }


### PR DESCRIPTION
Use modules as namespace markers, use newtypes, etc.